### PR TITLE
[913] Made site speed sampled 100% of the time

### DIFF
--- a/brambling/templates/brambling/__base.html
+++ b/brambling/templates/brambling/__base.html
@@ -92,7 +92,7 @@
 				m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 				})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-				ga('create', '{{ GOOGLE_ANALYTICS_UA }}', '{{ GOOGLE_ANALYTICS_DOMAIN }}');
+				ga('create', '{{ GOOGLE_ANALYTICS_UA }}', '{{ GOOGLE_ANALYTICS_DOMAIN }}', {'siteSpeedSampleRate': 100});
 				ga('send', 'pageview');
 			</script>
 		{% endif %}


### PR DESCRIPTION
This should improve our ability to view site speed metrics / get suggestions under Behavior > Site Speed > Speed Suggestions - assuming I understand what this does. Here are the docs: https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#siteSpeedSampleRate

Resolved #913