### PR TITLE
Removed discount-related code from non-payment pages

### DIFF
--- a/brambling/templates/brambling/event/order/hosting.html
+++ b/brambling/templates/brambling/event/order/hosting.html
@@ -8,8 +8,6 @@
 	{{ block.super }}
 	<script type="text/javascript" src="{% static "brambling/brambling.hostingform.js" %}"></script>
 
-	{% include 'brambling/event/order/_use_discount_js.html' %}
-
 	<script>
 		$(function(){
 			$('#id_providing_housing').on('change', function() {

--- a/brambling/templates/brambling/event/order/shop.html
+++ b/brambling/templates/brambling/event/order/shop.html
@@ -7,8 +7,6 @@
 {% block javascripts %}
 	{{ block.super }}
 
-	{% include 'brambling/event/order/_use_discount_js.html' %}
-
 	<script type="text/javascript" src="{% static "zenaida/js/bootstrap/carousel.js" %}"></script>
 {% endblock %}
 
@@ -48,31 +46,6 @@
 						</div>
 					{% endif %}
 				{% endwith %}
-
-				<div class='panel panel-default' id='discounts'>
-					<header class='panel-heading'>
-						<div class='panel-title'>
-							<i class="fa fa-fw fa-gift"></i> Discounts
-						</div>
-					</header>
-					<div class='list-group relative'>
-						{% for discount in discounts %}
-							<div class='list-group-item'>
-								{{ discount.name }} <em class='text-muted'>{{ discount.code }}</em>
-							</div>
-						{% endfor %}
-						<form id='discountForm'>
-						<div class='list-group-item'>
-							<div class='input-group'>
-								<input id='discountCode' class='form-control' placeholder='Discount code' autocomplete='off'>
-								<span class='input-group-btn'>
-									<button id='discountCodeButton' class='btn btn-default' type='submit'><span class='fa fa-plus'></span></button>
-								</span>
-							</div>
-						</div>
-						</form>
-					</div>{# /.list-group #}
-				</div>
 			</div>
 			<div class="col-md-7 col-md-pull-5 margin-leader margin-leader-md-0">
 				{% for options in option_list %}

--- a/brambling/templates/brambling/event/order/survey.html
+++ b/brambling/templates/brambling/event/order/survey.html
@@ -7,8 +7,6 @@
 {% block javascripts %}
 	{{ block.super }}
 
-	{% include 'brambling/event/order/_use_discount_js.html' %}
-
 	<script>
 		$(function(){
 			$('#id_heard_through').on('change', function() {

--- a/brambling/views/orders.py
+++ b/brambling/views/orders.py
@@ -442,9 +442,6 @@ brambling_boughtitem.status != 'refunded'
         })
 
         context['item_options'] = item_options
-        if self.order is not None:
-            context['discounts'] = Discount.objects.filter(
-                orderdiscount__order=self.order).distinct()
         return context
 
 


### PR DESCRIPTION
This is a standalone first step for #763. It removes discount forms from non-payment pages. This is non-destructive and may potentially resolve some issues folks are having.