### PR TITLE
Removed zenaida hints usage

### DIFF
--- a/brambling/templates/brambling/__base.html
+++ b/brambling/templates/brambling/__base.html
@@ -79,7 +79,6 @@
 		<script type="text/javascript" src="{% static "zenaida/js/bootstrap/dropdown.js" %}"></script>
 		<script type="text/javascript" src="{% static "zenaida/js/jquery.shorten.js" %}"></script>
 		<script type="text/javascript" src="{% static "brambling/lib/bootstrap-datepicker/bootstrap-datepicker.js" %}"></script>
-		<script type="text/javascript" src="{% static "hints/hints.js" %}"></script>
 		<script type="text/javascript" src="{% static "brambling/brambling.kickoff.js" %}"></script>
 		<script type="text/javascript" src="{% static "brambling/brambling.utils.js" %}"></script>
 		<script type="text/javascript" src="{% static "brambling/brambling.countdown.js" %}"></script>

--- a/brambling/templates/brambling/dashboard.html
+++ b/brambling/templates/brambling/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "brambling/__base_xl.html" %}
 
-{% load staticfiles hints %}
+{% load staticfiles %}
 
 {% block title %}{% if request.user.is_authenticated %}Your events – {% endif %}{{ block.super }}{% endblock %}
 
@@ -70,44 +70,6 @@
 			{% block messages %}
 				{% include "brambling/layouts/_messages.html" %}
 			{% endblock %}
-
-			{% if request.user.is_authenticated %}
-				{% hint request.user "welcome" %}
-					<div class="alert alert-info margin-trailer" id="welcomeHint">
-						<form action="{{ hint.dismiss_action }}" method="post" data-dismiss-hint="#welcomeHint">
-
-							{% csrf_token %}
-							{{ hint.dismiss_form }}
-
-							<button class="close"><span aria-hidden="true">&times;</span></button>
-
-							<p><strong>Welcome to Dancerfly!</strong></p>
-
-							<p>
-								Thanks for signing up for Dancerfly.
-								We&#8217;re happy to have you here! If you were registering
-								for an event, head back to that event page. We&#8217;ll keep
-								you logged in so you can register quickly.
-							</p>
-							<p>
-								Below is a list of upcoming events we think you might be
-								interested in. If there&#8217;s not much listed there it&#8217;s
-								because there aren&#8217;t enough events coming up or because
-								your dance preferences are too restrictive. You can update those
-								preferences (and other settings) on your
-								<a href="{% url "brambling_user_account"%}" class="alert-link">profile settings</a>
-								page.
-							</p>
-							<p>
-								When you&#8217;re ready to use the website on your own, go ahead
-								and dismiss this message with the <strong>&times;</strong> in the corner. We won&#8217;t
-								show it again.
-							</p>
-
-						</form>
-					</div>
-				{% endhint %}
-			{% endif %}
 
 			<h1 class="margin-leader-0">Upcoming Events</h1>
 

--- a/brambling/templates/brambling/organization/detail.html
+++ b/brambling/templates/brambling/organization/detail.html
@@ -1,6 +1,6 @@
 {% extends "brambling/layouts/12_sm.html" %}
 
-{% load staticfiles hints %}
+{% load staticfiles %}
 
 {% block title %}{{ organization.name }} – {{ block.super }}{% endblock %}
 

--- a/dancerfly_project/settings.py
+++ b/dancerfly_project/settings.py
@@ -59,7 +59,6 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'zenaida',
-    'zenaida.contrib.hints',
     'floppyforms',
     'django_filters',
     'daguerre',

--- a/dancerfly_project/urls.py
+++ b/dancerfly_project/urls.py
@@ -7,7 +7,6 @@ urlpatterns = patterns(
     url(r'^grappelli/', include('grappelli.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^talkback/', include('talkback.urls')),
-    url(r'^hints/', include('zenaida.contrib.hints.urls')),
     url(r'^', include('brambling.urls')),
 )
 


### PR DESCRIPTION
Resolved #918. This was the only hint we had in place. I think we can get rid of it - I suspect that users will already be able to figure out how to use the site. And if we are concerned about the issues this hint seems to be trying to address, we should open tickets to handle them separately. Specifically:

- [ ] Redirect users back to events after creating accounts (which I would expect us to do already but if not it would be a good ticket to have)
- [ ] Remove user "dance preferences" as a feature. It's a weird UX and we don't have enough events at this time to try to be search-driven.

<img width="500" alt="screen shot 2019-03-07 at 12 11 19 am" src="https://user-images.githubusercontent.com/299979/53941911-4170c300-406e-11e9-82d3-d8aaf3b86899.png">
