### PR TITLE
#951 Removed old event url shim

### DIFF
--- a/brambling/tests/functional/test_organizer_views.py
+++ b/brambling/tests/functional/test_organizer_views.py
@@ -504,3 +504,25 @@ class OrderDetailViewTest(TestCase):
         self.assertEqual(response['Location'], self.url)
         self.attendee.refresh_from_db()
         self.assertEqual(self.attendee.notes, 'Hello')
+
+
+class OrganizationDetailViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.organization = OrganizationFactory()
+
+    def test_view_succeeds(self):
+        url = reverse(
+            'brambling_organization_detail',
+            kwargs={'organization_slug': self.organization.slug},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_404s_if_org_does_not_exist(self):
+        url = reverse(
+            'brambling_organization_detail',
+            kwargs={'organization_slug': 'not_a_real_org'},
+        )
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 404)

--- a/brambling/views/organizer.py
+++ b/brambling/views/organizer.py
@@ -239,13 +239,7 @@ class OrganizationDetailView(DetailView):
     slug_url_kwarg = 'organization_slug'
 
     def get(self, request, *args, **kwargs):
-        try:
-            self.object = self.get_object()
-        except Http404:
-            # Backwards-compatibility for pre-org event links
-            # Added March 2015
-            event = get_object_or_404(Event, slug=kwargs['organization_slug'])
-            return HttpResponseRedirect(event.get_absolute_url())
+        self.object = self.get_object()
         context = self.get_context_data(object=self.object)
         return self.render_to_response(context)
 


### PR DESCRIPTION
Resolved #951. Basically, we had a shim in place for old event URLs but the logic wasn't sufficient to handle the current load of events, and given it's 5 years old I think we can just get rid of it at this point.